### PR TITLE
Add Generic SQLAlchemy Mutation

### DIFF
--- a/graphene_sqlalchemy/__init__.py
+++ b/graphene_sqlalchemy/__init__.py
@@ -4,7 +4,8 @@ from .mutations import (
     SQLAlchemyCreate,
     SQLAlchemyDelete,
     SQLAlchemyUpdate,
-    SQLAlchemyListDelete
+    SQLAlchemyListDelete,
+    SQLAlchemyMutation
 )
 from .utils import get_query, get_session
 
@@ -18,6 +19,7 @@ __all__ = [
     'SQLAlchemyUpdate',
     'SQLAlchemyDelete',
     'SQLAlchemyListDelete',
+    'SQLAlchemyMutation',
     'get_query',
     'get_session'
 ]

--- a/graphene_sqlalchemy/mutations.py
+++ b/graphene_sqlalchemy/mutations.py
@@ -1,6 +1,7 @@
 from graphene import Argument, Field, List, Mutation
 from graphene.types.objecttype import ObjectTypeOptions
 from graphene.types.utils import yank_fields_from_attrs
+from graphene.types.mutation import MutationOptions
 from graphene.utils.props import props
 from sqlalchemy.inspection import inspect as sqlalchemyinspect
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -10,7 +11,7 @@ from .registry import get_global_registry
 from .utils import get_session, get_snake_or_camel_attr
 
 
-class SQLAlchemyMutationOptions(ObjectTypeOptions):
+class SQLAlchemyMutationOptions(MutationOptions):
     model = None  # type: Model
 
 
@@ -62,7 +63,8 @@ class SQLAlchemyMutation(Mutation):
 
     @classmethod
     def Field(cls, *args, **kwargs):
-        resolver = kwargs.get("resolver", cls._meta.resolver)
+        resolver = kwargs.get("resolver", None)
+        resolver = resolver if resolver else cls._meta.resolver
         return Field(
             cls._meta.output, args=cls._meta.arguments, resolver=resolver
         )

--- a/graphene_sqlalchemy/mutations.py
+++ b/graphene_sqlalchemy/mutations.py
@@ -1,7 +1,9 @@
 from graphene import Argument, Field, List, Mutation
 from graphene.types.objecttype import ObjectTypeOptions
 from graphene.types.utils import yank_fields_from_attrs
+from graphene.utils.props import props
 from sqlalchemy.inspection import inspect as sqlalchemyinspect
+from sqlalchemy.ext.hybrid import hybrid_property
 
 from graphene_sqlalchemy.types import construct_fields
 from .registry import get_global_registry
@@ -10,6 +12,60 @@ from .utils import get_session, get_snake_or_camel_attr
 
 class SQLAlchemyMutationOptions(ObjectTypeOptions):
     model = None  # type: Model
+
+
+class SQLAlchemyMutation(Mutation):
+    @classmethod
+    def __init_subclass_with_meta__(cls, model=None, registry=None, only_fields=(), exclude_fields=None, **options):
+        meta = SQLAlchemyMutationOptions(cls)
+        meta.model = model
+
+        model_inspect = sqlalchemyinspect(model)
+        cls._model_inspect = model_inspect
+
+        if not isinstance(exclude_fields, list):
+            if exclude_fields:
+                exclude_fields = list(exclude_fields)
+            else:
+                exclude_fields = []
+
+        for primary_key_column in model_inspect.primary_key:
+            if primary_key_column.autoincrement:
+                exclude_fields.append(primary_key_column.name)
+
+        for relationship in model_inspect.relationships:
+            exclude_fields.append(relationship.key)
+
+        for field in model_inspect.all_orm_descriptors:
+            if type(field) == hybrid_property:
+                exclude_fields.append(field.__name__)
+
+        if not registry:
+            registry = get_global_registry()
+
+        fields = construct_fields(model, registry, only_fields, exclude_fields)
+
+        argument_cls = getattr(cls, "Arguments", None)
+        if argument_cls:
+            fields.update(props(argument_cls))
+
+        arguments = yank_fields_from_attrs(
+            fields,
+            _as=Argument
+        )
+
+        super(SQLAlchemyMutation, cls).__init_subclass_with_meta__(_meta=meta, arguments=arguments, **options)
+
+    @classmethod
+    def mutate(cls, self, info, **kwargs):
+        pass
+
+    @classmethod
+    def Field(cls, *args, **kwargs):
+        resolver = kwargs.get("resolver", cls._meta.resolver)
+        return Field(
+            cls._meta.output, args=cls._meta.arguments, resolver=resolver
+        )
 
 
 class SQLAlchemyCreate(Mutation):


### PR DESCRIPTION
Adds a generic SQLAlchemy Mutation that given a SQLAlchemy ORM Model does the follow:
* Combines model fields with user supplied arguments to construct arguments for a mutation
* Removes relationships and hybrid property model fields from arguments
* Allows user to supply a mutation resolver to replace built in `mutate` resolver